### PR TITLE
Fix broken custom-setup link

### DIFF
--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -32,7 +32,7 @@ To create a new documentation site, run `npm init docs` and follow the prompts.
 Once the application has been generated, see the [README.md](https://github.com/jxnblk/mdx-docs/create-docs/templates/next/README.md)
 for more documentation.
 
-To add MDX Docs to an existing Next.js app, see the [Custom Setup](custom-setup) docs.
+To add MDX Docs to an existing Next.js app, see the [Custom Setup](https://jxnblk.com/mdx-docs/custom-setup) docs.
 
 ## Using MDX
 


### PR DESCRIPTION
The [custom setup](https://jxnblk.com/mdx-docs/#getting-started) link in the `Getting started` section is broken for me.
Hard-Coding the URL is pbbly not the best idea, but I honestly have no idea how to do it differently.
Maybe simply prepending a `/` would suffice?

Cool project btw! 👍 👏 