### PR TITLE
Fix broken links on mdx-docs website

### DIFF
--- a/docs/pages/components.md
+++ b/docs/pages/components.md
@@ -2,7 +2,7 @@
 # Components
 
 MDX Docs includes several components to quickly create custom documentation sites.
-All MDX Docs components' styles can be customized with [theming](theming.md).
+All MDX Docs components' styles can be customized with [theming](/theming).
 
 ## Installation
 

--- a/docs/pages/custom-setup.md
+++ b/docs/pages/custom-setup.md
@@ -89,8 +89,8 @@ export default class MyApp extends App {
 
 Use a custom theme or configure the MDX Docs components to change the look and feel of your site.
 
-- [Theming](theming.md)
-- [Components](components.md)
+- [Theming](/theming)
+- [Components](/components)
 
 [mdx-next]: https://mdxjs.com/getting-started/next
 [custom App]: https://github.com/zeit/next.js/#custom-app

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -29,10 +29,10 @@ npm init docs
 ## Getting Started
 
 To create a new documentation site, run `npm init docs` and follow the prompts.
-Once the application has been generated, see the [README.md](https://github.com/jxnblk/mdx-docs/create-docs/templates/next/README.md)
+Once the application has been generated, see the [README.md](https://github.com/jxnblk/mdx-docs/blob/master/next-mdx-docs/README.md)
 for more documentation.
 
-To add MDX Docs to an existing Next.js app, see the [Custom Setup](custom-setup) docs.
+To add MDX Docs to an existing Next.js app, see the [Custom Setup](/custom-setup) docs.
 
 ## Using MDX
 


### PR DESCRIPTION
There are a handful of links that are broken on http://jxnblk.com/mdx-docs/ site. This should fix them.