### PR TITLE
fix: add missing deps

### DIFF
--- a/templates/next/package-lock.json
+++ b/templates/next/package-lock.json
@@ -857,6 +857,118 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@mdx-js/loader": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-0.16.6.tgz",
+      "integrity": "sha512-DwQzr1pzzB7NifXHbotXO6fQzzKAhM3oI8qY35k8AafiZay12UiUULOLCg4keau7SO+fKd6OjXSrc1N+wU6J+Q==",
+      "dev": true,
+      "requires": {
+        "@mdx-js/mdx": "^0.16.6",
+        "@mdx-js/tag": "^0.16.6",
+        "loader-utils": "^1.1.0"
+      },
+      "dependencies": {
+        "@mdx-js/mdx": {
+          "version": "0.16.6",
+          "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-0.16.6.tgz",
+          "integrity": "sha512-OJDun9/lt8c5tIWVNwjgFIkHtSWR3HOS+CmM5nW3BJKY5i4RSeVLekWkcCMpzujZtBF1frbjTM4bF9fD6LN8mQ==",
+          "dev": true,
+          "requires": {
+            "change-case": "^3.0.2",
+            "detab": "^2.0.0",
+            "mdast-util-to-hast": "^4.0.0",
+            "remark-parse": "^6.0.0",
+            "remark-squeeze-paragraphs": "^3.0.1",
+            "to-style": "^1.3.3",
+            "unified": "^7.0.0",
+            "unist-builder": "^1.0.1",
+            "unist-util-visit": "^1.3.0"
+          }
+        },
+        "@mdx-js/tag": {
+          "version": "0.16.6",
+          "resolved": "https://registry.npmjs.org/@mdx-js/tag/-/tag-0.16.6.tgz",
+          "integrity": "sha512-cTv+DLNEUPjAExizE2ujdUxQ6OO3z/ttzeh2JAweMh5uLfWHceSQiX9sbl16AYuV00MiOu//6gHoa+Ob2NZxNA==",
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+          "dev": true
+        },
+        "mdast-util-to-hast": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-4.0.0.tgz",
+          "integrity": "sha512-yOTZSxR1aPvWRUxVeLaLZ1sCYrK87x2Wusp1bDM/Ao2jETBhYUKITI3nHvgy+HkZW54HuCAhHnS0mTcbECD5Ig==",
+          "dev": true,
+          "requires": {
+            "collapse-white-space": "^1.0.0",
+            "detab": "^2.0.0",
+            "mdast-util-definitions": "^1.2.0",
+            "mdurl": "^1.0.1",
+            "trim": "0.0.1",
+            "trim-lines": "^1.0.0",
+            "unist-builder": "^1.0.1",
+            "unist-util-generated": "^1.1.0",
+            "unist-util-position": "^3.0.0",
+            "unist-util-visit": "^1.1.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "remark-parse": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+          "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
+          "dev": true,
+          "requires": {
+            "collapse-white-space": "^1.0.2",
+            "is-alphabetical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-whitespace-character": "^1.0.0",
+            "is-word-character": "^1.0.0",
+            "markdown-escapes": "^1.0.0",
+            "parse-entities": "^1.1.0",
+            "repeat-string": "^1.5.4",
+            "state-toggle": "^1.0.0",
+            "trim": "0.0.1",
+            "trim-trailing-lines": "^1.0.0",
+            "unherit": "^1.0.4",
+            "unist-util-remove-position": "^1.0.0",
+            "vfile-location": "^2.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "unified": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+          "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "@types/vfile": "^3.0.0",
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "trough": "^1.0.0",
+            "vfile": "^3.0.0",
+            "x-is-string": "^0.1.0"
+          }
+        },
+        "vfile": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+          "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^2.0.0",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "^1.0.0",
+            "vfile-message": "^1.0.0"
+          }
+        }
+      }
+    },
     "@mdx-js/mdx": {
       "version": "0.15.5",
       "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-0.15.5.tgz",
@@ -879,6 +991,39 @@
         "create-react-context": "^0.2.2",
         "hoist-non-react-statics": "^2.5.5",
         "prop-types": "^15.6.1"
+      }
+    },
+    "@types/node": {
+      "version": "10.12.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+      "dev": true
+    },
+    "@types/unist": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.2.tgz",
+      "integrity": "sha512-iHI60IbyfQilNubmxsq4zqSjdynlmc2Q/QvH9kjzg9+CCYVVzq1O6tc7VBzSygIwnmOt07w80IG6HDQvjv3Liw==",
+      "dev": true
+    },
+    "@types/vfile": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
+      "integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/unist": "*",
+        "@types/vfile-message": "*"
+      }
+    },
+    "@types/vfile-message": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
+      "integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/unist": "*"
       }
     },
     "@webassemblyjs/ast": {
@@ -2161,6 +2306,11 @@
       "resolved": "https://registry.npmjs.org/emitter-mixin/-/emitter-mixin-0.0.3.tgz",
       "integrity": "sha1-WUjLKG8uSO3DslGnz8H3iDOW1lw="
     },
+    "emoji-regex": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+      "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
+    },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -3076,6 +3226,14 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
+    "github-slugger": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.2.0.tgz",
+      "integrity": "sha512-wIaa75k1vZhyPm9yWrD08A5Xnx/V+RmzGrpjQuLemGKSb77Qukiaei58Bogrl/LZSADDfPzKJX8jhLs4CRTl7Q==",
+      "requires": {
+        "emoji-regex": ">=6.0.0 <=6.1.1"
+      }
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -3567,6 +3725,11 @@
         "upper-case": "^1.1.0"
       }
     },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+    },
     "is-whitespace-character": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
@@ -3712,6 +3875,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
+    "lodash.toarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
+    },
     "log-update": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
@@ -3847,6 +4015,11 @@
         "unist-util-visit": "^1.1.0",
         "xtend": "^4.0.1"
       }
+    },
+    "mdast-util-to-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.0.5.tgz",
+      "integrity": "sha512-2qLt/DEOo5F6nc2VFScQiHPzQ0XXcabquRJxKMhKte8nt42o08HUxNDPk7tt0YPxnWjAT11I1SYi0X0iPnfI5A=="
     },
     "mdurl": {
       "version": "1.0.1",
@@ -4146,6 +4319,14 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "requires": {
         "lower-case": "^1.1.1"
+      }
+    },
+    "node-emoji": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
+      "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
+      "requires": {
+        "lodash.toarray": "^4.4.0"
       }
     },
     "node-fetch": {
@@ -4889,6 +5070,33 @@
         }
       }
     },
+    "remark-autolink-headings": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/remark-autolink-headings/-/remark-autolink-headings-5.1.0.tgz",
+      "integrity": "sha512-+dMaZ9qxEiuC7EyCWdwE9cm6AlVP+GaoEIdD8DtjnqZdMEInt0fRoDNrILOBL3gh6v3MhzfGeus4VcRVXniYQQ==",
+      "requires": {
+        "extend": "^3.0.2",
+        "unist-util-visit": "^1.0.1"
+      }
+    },
+    "remark-emoji": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-2.0.2.tgz",
+      "integrity": "sha512-E8ZOa7Sx1YS9ivWJ8U9xpA8ldzZ4VPAfyUaKqhr1/Pr5Q8ZdQHrpDg6S+rPzMw8t89KNViB/oG9ZdJSFDrUXpA==",
+      "requires": {
+        "node-emoji": "^1.8.1",
+        "unist-util-visit": "^1.4.0"
+      }
+    },
+    "remark-images": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/remark-images/-/remark-images-0.16.1.tgz",
+      "integrity": "sha512-QAQmAV773JlqtVsqgrJJNZmE50YcTumMidAgf7y+3eTt0EfJsJQsyjyB+x6xu9OT3a5c7sKTdASbCr3lyRKhbg==",
+      "requires": {
+        "is-url": "^1.2.2",
+        "unist-util-visit": "^1.3.0"
+      }
+    },
     "remark-parse": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
@@ -4911,12 +5119,30 @@
         "xtend": "^4.0.1"
       }
     },
+    "remark-slug": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/remark-slug/-/remark-slug-5.1.1.tgz",
+      "integrity": "sha512-r591rdoDPJkSSAVvEaTVUkqbMp7c7AyZfif14V0Dp66GQkOHzaPAS6wyhawSbqpS0ZdTnfJS+TltFoxzi6bdIA==",
+      "requires": {
+        "github-slugger": "^1.0.0",
+        "mdast-util-to-string": "^1.0.0",
+        "unist-util-visit": "^1.0.0"
+      }
+    },
     "remark-squeeze-paragraphs": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/remark-squeeze-paragraphs/-/remark-squeeze-paragraphs-3.0.2.tgz",
       "integrity": "sha512-XFks+7F6FKmGkJcGyAvJ1GmqtPID9piDtJhrgglIGqg1VRTjpfft6UtGVGCuYnliZt8J72KPG8bwiJkwY6NDOw==",
       "requires": {
         "mdast-squeeze-paragraphs": "^3.0.0"
+      }
+    },
+    "remark-unwrap-images": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/remark-unwrap-images/-/remark-unwrap-images-0.1.0.tgz",
+      "integrity": "sha512-70j4Qy6Mj2+0MmQOmSES40+hO4BQGm2hhb5qNq8LwTlGrmyE4VWsKPIryELiBK0TZP57crOkSOD/AFqPjxvekQ==",
+      "requires": {
+        "unist-util-visit-parents": "^2.0.1"
       }
     },
     "remove-trailing-separator": {

--- a/templates/next/package.json
+++ b/templates/next/package.json
@@ -11,6 +11,14 @@
     "next": "^7.0.1",
     "prop-types": "^15.6.2",
     "react": "^16.4.1",
-    "react-dom": "^16.4.1"
+    "react-dom": "^16.4.1",
+    "remark-autolink-headings": "^5.1.0",
+    "remark-emoji": "^2.0.2",
+    "remark-images": "^0.16.1",
+    "remark-slug": "^5.1.1",
+    "remark-unwrap-images": "^0.1.0"
+  },
+  "devDependencies": {
+    "@mdx-js/loader": "^0.16.6"
   }
 }


### PR DESCRIPTION
The template used by `npm init docs` was missing deps used in the
next.config.js. This PR adds them in ✨ 🎷 🐩 

Without it you have to work through a bunch of _module not found_ errors,  one by one.

Fixes #20 (kinda, I can't fix people using old npm, but we can make the init template work)