### PR TITLE
Add node_modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 coverage
+node_modules


### PR DESCRIPTION
Pulled down this repo to explore it, and after an `npm ci`, I noticed that the `node_modules` directory was being tracked by git.