### PR TITLE
Fixed dead link to README in docs

### DIFF
--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -29,7 +29,7 @@ npm init docs
 ## Getting Started
 
 To create a new documentation site, run `npm init docs` and follow the prompts.
-Once the application has been generated, see the [README.md](https://github.com/jxnblk/mdx-docs/blob/master/next-mdx-docs/README.md)
+Once the application has been generated, see the [README.md](https://github.com/jxnblk/mdx-docs/blob/master/README.md)
 for more documentation.
 
 To add MDX Docs to an existing Next.js app, see the [Custom Setup](/custom-setup) docs.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1663018/65618082-b7e1fd80-df8b-11e9-8a00-28da21aacb14.png)

This README link is dead on the website. This change fixes it.